### PR TITLE
Added POST for /items and verificiation for shape of lisitng object

### DIFF
--- a/api/App.py
+++ b/api/App.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
+from Utils import verifyListingShape, makeId
 app = Flask(__name__)
 CORS(app)
 
@@ -28,10 +29,19 @@ listings = [
 ]
 
 
-@app.route('/items')
+@app.route('/items', methods=['GET', 'POST'])
 def get_items():
     if request.method == 'GET':
         return jsonify({"listings": listings}), 200
+    if request.method == 'POST':
+        listing = request.get_json()
+        issues = verifyListingShape(listing)
+        if len(issues) > 0:
+            return jsonify({"message": "Bad request, missing fields",
+                            "details": issues}), 400
+        listing['id'] = makeId()
+        listings.append(listing)
+        return jsonify(listing), 201
 
 
 @app.route('/items/<id>')

--- a/api/Utils.py
+++ b/api/Utils.py
@@ -1,0 +1,14 @@
+import random
+
+
+def verifyListingShape(listing: dict) -> list:
+    LISTING_FIELDS = ['title', 'price', 'desc', 'lngLat', 'imgUrl']
+    missingFields = []
+    for field in LISTING_FIELDS:
+        if not field in listing:
+            missingFields.append(field)
+    return missingFields
+
+
+def makeId() -> str:
+    return str(random.randint(0, 9999))

--- a/api/test_utils.py
+++ b/api/test_utils.py
@@ -1,0 +1,33 @@
+import pytest
+from Utils import verifyListingShape
+
+
+@pytest.fixture
+def listing_shape():
+    return ({
+        'title': 'test',
+        'price': 100.29,
+        'desc': 'lorem ipsum this is a test',
+        'lngLat': [-120.45, 35.38],
+        'imgUrl': 'testingtest.com'
+    })
+
+
+def test_correct_shape(listing_shape):
+    EXPECTED = []
+    assert verifyListingShape(listing_shape) == []
+
+
+def test_missing_one_field(listing_shape: dict):
+    INPUT = listing_shape
+    INPUT.pop('title')
+    EXPECTED = ['title']
+    assert verifyListingShape(INPUT) == EXPECTED
+
+
+def test_missing_two_fields(listing_shape: dict):
+    INPUT = listing_shape
+    INPUT.pop('title')
+    INPUT.pop('price')
+    EXPECTED = ['title', 'price']
+    assert verifyListingShape(INPUT) == EXPECTED


### PR DESCRIPTION
bad request example:
![image](https://user-images.githubusercontent.com/49253708/117509057-6a3abe80-af3e-11eb-860c-78e286e8e4ba.png)

success example:
![image](https://user-images.githubusercontent.com/49253708/117509085-79ba0780-af3e-11eb-8b4c-5d18c3281834.png)
